### PR TITLE
Migrate to Python3

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -15,7 +15,7 @@ Description: Bookmarks merger allows the user to merge multiple firefox bookmark
 Keywords: firefox
 Platform: UNKNOWN
 Classifier: License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)
-Classifier: Programming Language :: Python
+Classifier: Programming Language :: Python :: 3
 Classifier: Development Status :: 3 - Alpha
 Classifier: Environment :: Console
 Classifier: Intended Audience :: Developers

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -15,7 +15,7 @@ Description: Bookmarks merger allows the user to merge multiple firefox bookmark
 Keywords: firefox
 Platform: UNKNOWN
 Classifier: License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)
-Classifier: Programming Language :: Python :: 3
+Classifier: Programming Language :: Python :: 3.7
 Classifier: Development Status :: 3 - Alpha
 Classifier: Environment :: Console
 Classifier: Intended Audience :: Developers

--- a/bookmark_merger.py
+++ b/bookmark_merger.py
@@ -30,27 +30,27 @@ htmlfiles=[]
 for path in dir_path:
     if recursive==True:
         for root,dirs,files in os.walk(path):
-            print root
+            print(root)
             htmlfiles_tmp=[os.path.join(root,fils) for fils in files if fils.split('.')[-1].lower()=='html']
             htmlfiles.extend(htmlfiles_tmp)
     else:
         root=os.path.abspath(path)
         files=os.listdir(path)
-        print root
+        print(root)
         htmlfiles_tmp=[os.path.join(root,fils) for fils in files if fils.split('.')[-1].lower()=='html']
         htmlfiles.extend(htmlfiles_tmp)
 
 
-print
+print()
 result={}
 numhref=0
 for bookmarkfile in htmlfiles:
-        print '##### parsing ', os.path.relpath(bookmarkfile,path)
+        print('##### parsing ', os.path.relpath(bookmarkfile,path))
         parsedfile=bpp.bookmarkshtml.parseFile(file(bookmarkfile))
         numhref+=len(bpp.hyperlinks(parsedfile))
-        print '#### creating a bookmarkDict '
+        print('#### creating a bookmarkDict ')
         bmDict=bpp.bookmarkDict(parsedfile)
-        print '#### merging latest file into result'
+        print('#### merging latest file into result')
         result=bpp.merge_bookmarkDict(result,bmDict)
     
 finalfile=file(outfile, 'w')
@@ -58,9 +58,9 @@ finalstr=bpp.serialize_bookmarkDict(result)
 finalfile.write(finalstr)
 finalfile.close()
 
-print 'total nunber of hyperlinks found = ', numhref
-print 'number of hyperlinks in final file=', len(bpp.hyperlinks_bookmarkDict(result))
-print 'number of unique hyperlinks =', len(set(bpp.hyperlinks_bookmarkDict(result)))
-print 'number of folders =', bpp.count_folders(result)
+print('total nunber of hyperlinks found = ', numhref)
+print('number of hyperlinks in final file=', len(bpp.hyperlinks_bookmarkDict(result)))
+print('number of unique hyperlinks =', len(set(bpp.hyperlinks_bookmarkDict(result))))
+print('number of folders =', bpp.count_folders(result))
 
 

--- a/bookmark_merger.py
+++ b/bookmark_merger.py
@@ -46,14 +46,14 @@ result={}
 numhref=0
 for bookmarkfile in htmlfiles:
         print('##### parsing ', os.path.relpath(bookmarkfile,path))
-        parsedfile=bpp.bookmarkshtml.parseFile(file(bookmarkfile))
+        parsedfile = bpp.bookmarkshtml.parseFile(bookmarkfile)
         numhref+=len(bpp.hyperlinks(parsedfile))
         print('#### creating a bookmarkDict ')
         bmDict=bpp.bookmarkDict(parsedfile)
         print('#### merging latest file into result')
         result=bpp.merge_bookmarkDict(result,bmDict)
     
-finalfile=file(outfile, 'w')
+finalfile = open(outfile, 'w')
 finalstr=bpp.serialize_bookmarkDict(result)
 finalfile.write(finalstr)
 finalfile.close()

--- a/bookmark_pyparser.py
+++ b/bookmark_pyparser.py
@@ -96,7 +96,7 @@ def hyperlinks(parseresults):
     except:
         itemlist=[] # an empty folder
     for item in parseresults:
-        if type(item)==bytes:
+        if type(item) == str:
             pass
         elif 'Folder' in list(item.keys()):
             #recursive
@@ -113,7 +113,7 @@ def clean_tree(parseresults):
     except:
         itemlist=[] # an empty folder
     for item in parseresults:
-        if type(item)==bytes:
+        if type(item) == str:
             pass
         elif 'Folder' in list(item.keys()):
             #recursive
@@ -137,7 +137,7 @@ def bookmarkDict(parseresults):
     except:
         pass
     for item in parseresults:
-        if type(item)==bytes:
+        if type(item) == str:
             pass
         elif 'Folder' in list(item.keys()):
             #print 'Creating a sub-bookmarkDict'
@@ -172,7 +172,7 @@ def _folder_serialize(parseresults,indent):
     sresult=indstr+parseresults[0]+'\n'
     sresult+=indstr+'<DL><p>'+'\n'
     for item in parseresults[1:]:
-        if type(item)==bytes:
+        if type(item) == str:
             sresult+=indstr+tab+item+'\n' #extra indentation
         elif 'Folder' in list(item.keys()):
             sresult+=_folder_serialize(item,indent+1)
@@ -186,7 +186,7 @@ def serialize(parseresults):
     result+='\n'
     result+='<DL><p>'+'\n'
     for item in parseresults[2:]:
-        if type(item)==bytes:
+        if type(item) == str:
             result+='    '+item+'\n' #indentation
         else:
             result+=_folder_serialize(item,indent=1)
@@ -218,7 +218,7 @@ def serialize_bookmarkDict(bookdict):
     result+='\n'
     result+='<DL><p>'+'\n'
     for item in list(bookdict.values()):
-        if type(item)==bytes:
+        if type(item) == str:
             result+='    '+item+'\n' #indentation
         else:
             result+=_folder_serialize_bookmarkDict(item,indent=1)
@@ -257,7 +257,7 @@ def uniq(seq):
 def top_folders_dict(parseresults):
     itemlist={} # top folder?
     for j,item in enumerate(parseresults):
-        if type(item)==bytes:
+        if type(item) == str:
             pass
         elif 'Folder' in list(item.keys()):
             try:

--- a/bookmark_pyparser.py
+++ b/bookmark_pyparser.py
@@ -409,10 +409,10 @@ def count_folders(bookmarkdict):
 if __name__=="__main__":
     ##test
     #Loads a bookmarks.html file. 
-    #f=file("bookmarks 141208.html",'r')
-    #f=file("workshop\\old1\\test\\bookmarks test.html","r")
-    #f=file("bookmarks zi.html","r")
-    #f=file("test.html")
+    #f=open("bookmarks 141208.html",'r')
+    #f=open("workshop\\old1\\test\\bookmarks test.html","r")
+    #f=open("bookmarks zi.html","r")
+    #f=open("test.html")
     #bms=f.read()
     #f.close()
     #parsing 
@@ -429,7 +429,7 @@ if __name__=="__main__":
     #outfile.write(output)
     #outfile.close()
 
-    #f2=file("workshop\\old1\\test\\bookmarks zi.html","r")
+    #f2=open("workshop\\old1\\test\\bookmarks zi.html","r")
     #bms2=f2.read()
     #f2.close()
     #parsing 

--- a/bookmark_pyparser.py
+++ b/bookmark_pyparser.py
@@ -48,7 +48,8 @@ Do Not Edit! -->
      DO NOT EDIT! --><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><title>Bookmarks</title></head>
 """]
 #headers = [ pp.And( pp.Literal(line.strip()) for line in head.splitlines()) for head in headers] # requires furthers changes to serialisation
-headers2 = [pp.Combine( pp.And( pp.Literal(line.strip())+pp.ZeroOrMore(pp.White()) for line in head.splitlines()) ,adjacent=False) for head in headers]
+headers2 = [pp.Combine(pp.And([pp.Literal(line.strip())+pp.ZeroOrMore(pp.White())
+                               for line in head.splitlines()]), adjacent=False) for head in headers]
 
 
 #header1

--- a/example.py
+++ b/example.py
@@ -16,7 +16,7 @@ result={}
 numhref=0
 for bookmarkfile in htmlfiles:
         print('############################## parsing ', bookmarkfile)
-        parsedfile=bpp.bookmarkshtml.parseFile(file(bookmarkfile))
+        parsedfile = bpp.bookmarkshtml.parseFile(bookmarkfile)
         numhref+=len(bpp.hyperlinks(parsedfile))
         print('############################## creating a bookmarkDict ')
         bmDict=bpp.bookmarkDict(parsedfile)
@@ -24,7 +24,7 @@ for bookmarkfile in htmlfiles:
         result=bpp.merge_bookmarkDict(result,bmDict)
     
 
-finalfile=file('merged bookmarks.html', 'w')
+finalfile = open('merged bookmarks.html', 'w')
 finalstr=bpp.serialize_bookmarkDict(result)
 finalfile.write(finalstr)
 finalfile.close()

--- a/example.py
+++ b/example.py
@@ -7,20 +7,20 @@ import bookmark_pyparser as bpp
 import os
 htmlfiles=[]
 for root,dirs,files in os.walk(bookmark_dir):
-	print root
+	print(root)
 	htmlfiles_tmp=[os.path.join(root,fils) for fils in files if fils.split('.')[-1].lower()=='html']
 	htmlfiles.extend(htmlfiles_tmp)
 
-print
+print()
 result={}
 numhref=0
 for bookmarkfile in htmlfiles:
-        print '############################## parsing ', bookmarkfile
+        print('############################## parsing ', bookmarkfile)
         parsedfile=bpp.bookmarkshtml.parseFile(file(bookmarkfile))
         numhref+=len(bpp.hyperlinks(parsedfile))
-        print '############################## creating a bookmarkDict '
+        print('############################## creating a bookmarkDict ')
         bmDict=bpp.bookmarkDict(parsedfile)
-        print '############################## merging latest file into result'
+        print('############################## merging latest file into result')
         result=bpp.merge_bookmarkDict(result,bmDict)
     
 
@@ -29,7 +29,7 @@ finalstr=bpp.serialize_bookmarkDict(result)
 finalfile.write(finalstr)
 finalfile.close()
 
-print 'total nunber of hyperlinks found = ', numhref
-print 'number of hyperlinks in final file=', len(bpp.hyperlinks_bookmarkDict(result))
-print 'number of unique hyperlinks =', len(set(bpp.hyperlinks_bookmarkDict(result)))
-print 'number of folders =', bpp.count_folders(result)
+print('total nunber of hyperlinks found = ', numhref)
+print('number of hyperlinks in final file=', len(bpp.hyperlinks_bookmarkDict(result)))
+print('number of unique hyperlinks =', len(set(bpp.hyperlinks_bookmarkDict(result))))
+print('number of folders =', bpp.count_folders(result))

--- a/example_bookmark_merger.py
+++ b/example_bookmark_merger.py
@@ -30,27 +30,27 @@ htmlfiles=[]
 for path in dir_path:
     if recursive==True:
         for root,dirs,files in os.walk(path):
-            print root
+            print(root)
             htmlfiles_tmp=[os.path.join(root,fils) for fils in files if fils.split('.')[-1].lower()=='html']
             htmlfiles.extend(htmlfiles_tmp)
     else:
         root=os.path.abspath(path)
         files=os.listdir(path)
-        print root
+        print(root)
         htmlfiles_tmp=[os.path.join(root,fils) for fils in files if fils.split('.')[-1].lower()=='html']
         htmlfiles.extend(htmlfiles_tmp)
 
 
-print
+print()
 result={}
 numhref=0
 for bookmarkfile in htmlfiles:
-        print '##### parsing ', os.path.relpath(bookmarkfile,path)
+        print('##### parsing ', os.path.relpath(bookmarkfile,path))
         parsedfile=bpp.bookmarkshtml.parseFile(file(bookmarkfile))
         numhref+=len(bpp.hyperlinks(parsedfile))
-        print '#### creating a bookmarkDict '
+        print('#### creating a bookmarkDict ')
         bmDict=bpp.bookmarkDict(parsedfile)
-        print '#### merging latest file into result'
+        print('#### merging latest file into result')
         result=bpp.merge_bookmarkDict(result,bmDict)
     
 
@@ -59,9 +59,9 @@ finalstr=bpp.serialize_bookmarkDict(result)
 finalfile.write(finalstr)
 finalfile.close()
 
-print 'total nunber of hyperlinks found = ', numhref
-print 'number of hyperlinks in final file=', len(bpp.hyperlinks_bookmarkDict(result))
-print 'number of unique hyperlinks =', len(set(bpp.hyperlinks_bookmarkDict(result)))
-print 'number of folders =', bpp.count_folders(result)
+print('total nunber of hyperlinks found = ', numhref)
+print('number of hyperlinks in final file=', len(bpp.hyperlinks_bookmarkDict(result)))
+print('number of unique hyperlinks =', len(set(bpp.hyperlinks_bookmarkDict(result))))
+print('number of folders =', bpp.count_folders(result))
 
 

--- a/example_bookmark_merger.py
+++ b/example_bookmark_merger.py
@@ -46,7 +46,7 @@ result={}
 numhref=0
 for bookmarkfile in htmlfiles:
         print('##### parsing ', os.path.relpath(bookmarkfile,path))
-        parsedfile=bpp.bookmarkshtml.parseFile(file(bookmarkfile))
+        parsedfile = bpp.bookmarkshtml.parseFile(bookmarkfile)
         numhref+=len(bpp.hyperlinks(parsedfile))
         print('#### creating a bookmarkDict ')
         bmDict=bpp.bookmarkDict(parsedfile)
@@ -54,7 +54,7 @@ for bookmarkfile in htmlfiles:
         result=bpp.merge_bookmarkDict(result,bmDict)
     
 
-finalfile=file(outfile, 'w')
+finalfile = open(outfile, 'w')
 finalstr=bpp.serialize_bookmarkDict(result)
 finalfile.write(finalstr)
 finalfile.close()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ in the README file and on the sourceforge site.
         """,
         classifiers=[
           "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
-          "Programming Language :: Python",
+          "Programming Language :: Python :: 3",
           "Development Status :: 3 - Alpha",
           "Environment :: Console",
           "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ in the README file and on the sourceforge site.
         """,
         classifiers=[
           "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
-          "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3.7",
           "Development Status :: 3 - Alpha",
           "Environment :: Console",
           "Intended Audience :: Developers",


### PR DESCRIPTION
Migrating to Python 3 fixes the bug where bookmark order is lost. This is because Python 3 dictionaries preserve their order unlike those in Python 2.